### PR TITLE
Update documentation for functions with incorrect or outdated information

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -172,28 +172,6 @@ local SecurityMeasures: TSecurityMeasuresEnum = {
 ]=]
 
 --[=[
-	@function FromHex
-	@within BridgeNet2
-
-	Converts a hexadecimal string into a string of ASCII characters. This can be used for various purposes,
-	for example, converting a globally uniue identifier (GUID) into a binary string, which saves data. Or you
-	could convert a thread ID, or a memory address into a string for debugging purposes. Hexadecimal can be used
-	for a variety of purposes. The function uses string.char alongside tonumber(string, 16) to convert the
-	hexadecimal into a character code, which is converted into ASCII.
-
-	```lua
-	-- "Example hexadecimal string" in hex
-	local hexString = "4578616D706C652068657861646563696D616C20737472696E67"
-	local asciiString = BridgeNet2.FromHex(hexString)
-
-	print(asciiString) -- Prints 'Example hexadecimal string'
-	```
-
-	@param hexadecimal string
-	@return string
-]=]
-
---[=[
 	@function CreateUUID
 	@within BridgeNet2
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -197,18 +197,15 @@ local SecurityMeasures: TSecurityMeasuresEnum = {
 	@function CreateUUID
 	@within BridgeNet2
 
-	Converts a hexadecimal string into a string of ASCII characters. This can be used for various purposes,
-	for example, converting a globally uniue identifier (GUID) into a binary string, which saves data. Or you
-	could convert a thread ID, or a memory address into a string for debugging purposes. Hexadecimal can be used
-	for a variety of purposes. The function uses string.char alongside tonumber(string, 16) to convert the
-	hexadecimal into a character code, which is converted into ASCII.
+	Generates a new UUID (Universally Unique Identifier) in string format. This function uses the `GenerateGUID`
+	method provided by the HttpService object to create a new UUID, and then removes the hyphens from the string
+	before returning it.
 
 	```lua
-	-- "Example hexadecimal string" in hex
-	local hexString = "4578616D706C652068657861646563696D616C20737472696E67"
-	local asciiString = BridgeNet2.FromHex(hexString)
+	-- "Example of creating a uuid string"
+	local UUID = BridgeNet2.CreateUUID()
 
-	print(asciiString) -- Prints 'Example hexadecimal string'
+	print(UUID) -- Example output: "F7B64066F6B94012AA5FEFCEB38352E4"
 	```
 
 	@return string


### PR DESCRIPTION
This pull request updates the documentation for several functions in the "BridgeNet2" repository that have incorrect or outdated information. Specifically, the following changes have been made:

- For the `CreateUUID` function, the documentation has been updated to provide a clear description of what the function does and how to use it, along with an example usage.
- Additionally, a duplicate entry for the `FromHex` function in the documentation has been removed, so that there is now only one documented version of the function.

Overall, these changes should help make the documentation for these functions more complete and useful for developers using the "BridgeNet2" library.
